### PR TITLE
feat: add task management functionality with CRUD operations and UI Integration

### DIFF
--- a/src/apps/frontend/pages/dashboard/index.tsx
+++ b/src/apps/frontend/pages/dashboard/index.tsx
@@ -1,5 +1,38 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Button, H2, VerticalStackLayout } from 'frontend/components';
+import routes from 'frontend/constants/routes';
 
-const Dashboard: React.FC = () => <div></div>;
+const Dashboard: React.FC = () => (
+<div className="p-6">
+    <VerticalStackLayout gap={6}>
+        <H2>Dashboard</H2>
+        <div className="rounded-lg border border-stroke bg-white p-6 shadow-sm">
+            <div className="flex items-center justify-between mb-4">
+                <div>
+                    <h3 className="text-lg font-semibold">Quick Actions</h3>
+                    <p className="mt-1 text-sm text-slate-500">Common tasks and shortcuts to get you started.</p>
+                </div>
+            </div>
+
+            <div className="flex flex-wrap gap-4 items-center">
+                <Link to={routes.TASKS}>
+                    <Button>
+                        <span className="mr-2 inline-flex -mt-0.5" aria-hidden>
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4" />
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h11" />
+                            </svg>
+                        </span>
+                        Manage Tasks
+                    </Button>
+                </Link>
+
+                <div className="text-sm text-slate-500">or use the search to find items quickly</div>
+            </div>
+        </div>
+    </VerticalStackLayout>
+</div>
+);
 
 export default Dashboard;

--- a/src/apps/frontend/pages/index.ts
+++ b/src/apps/frontend/pages/index.ts
@@ -7,6 +7,7 @@ import Signup from 'frontend/pages/authentication/signup';
 import Dashboard from 'frontend/pages/dashboard';
 import Login from 'frontend/pages/login';
 import NotFound from 'frontend/pages/not-found/not-found.page';
+import Tasks from 'frontend/pages/tasks';
 
 export {
   About,
@@ -18,4 +19,5 @@ export {
   OTPVerificationPage,
   PhoneLogin,
   Login,
+  Tasks,
 };

--- a/src/apps/frontend/pages/tasks/index.tsx
+++ b/src/apps/frontend/pages/tasks/index.tsx
@@ -1,0 +1,297 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useFormik, FormikHelpers } from 'formik';
+import * as Yup from 'yup';
+import toast from 'react-hot-toast';
+
+import {
+  Button,
+  Flex,
+  FormControl,
+  Input,
+  ParagraphMedium,
+  VerticalStackLayout,
+} from 'frontend/components';
+import { ButtonType } from 'frontend/types/button';
+import { TaskService } from 'frontend/services';
+import { Task } from 'frontend/types';
+import { getAccessTokenFromStorage } from 'frontend/utils/storage-util';
+
+type TaskFormValues = {
+  title: string;
+  description: string;
+};
+
+const taskValidationSchema = Yup.object({
+  title: Yup.string().trim().required('Title is required'),
+  description: Yup.string().trim().required('Description is required'),
+});
+
+type ApiErrorShape = {
+  message?: string;
+  response?: {
+    data?: {
+      message?: string;
+    };
+  };
+};
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  if (typeof error === 'string' && error) {
+    return error;
+  }
+
+  if (error && typeof error === 'object') {
+    const { message, response } = error as ApiErrorShape;
+    if (response?.data?.message) {
+      return response.data.message;
+    }
+    if (message) {
+      return message;
+    }
+  }
+
+  return fallback;
+};
+
+const Tasks: React.FC = () => {
+  const accessToken = useMemo(() => getAccessTokenFromStorage(), []);
+  const taskService = useMemo(() => new TaskService(), []);
+
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [taskCount, setTaskCount] = useState(0);
+  const [isLoadingTasks, setIsLoadingTasks] = useState(false);
+  const [isSubmittingTask, setIsSubmittingTask] = useState(false);
+  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
+  const [deletingTaskId, setDeletingTaskId] = useState<string | null>(null);
+
+  const fetchTasks = useCallback(async () => {
+    if (!accessToken) {
+      setTasks([]);
+      setTaskCount(0);
+      return;
+    }
+
+    setIsLoadingTasks(true);
+    try {
+      const response = await taskService.listTasks(accessToken);
+      if (response.data) {
+        setTasks(response.data.items);
+        setTaskCount(response.data.totalCount);
+      }
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Unable to load tasks.'));
+    } finally {
+      setIsLoadingTasks(false);
+    }
+  }, [accessToken, taskService]);
+
+  useEffect(() => {
+    fetchTasks();
+  }, [fetchTasks]);
+
+  const formik = useFormik<TaskFormValues>({
+    initialValues: {
+      title: '',
+      description: '',
+    },
+    validationSchema: taskValidationSchema,
+    enableReinitialize: false,
+    onSubmit: async (
+      values: TaskFormValues,
+      formikHelpers: FormikHelpers<TaskFormValues>,
+    ) => {
+      if (!accessToken) {
+        toast.error('You need to be logged in to manage tasks.');
+        return;
+      }
+
+      setIsSubmittingTask(true);
+      const payload = {
+        title: values.title.trim(),
+        description: values.description.trim(),
+      };
+
+      try {
+        if (editingTaskId) {
+          await taskService.updateTask(accessToken, editingTaskId, payload);
+          toast.success('Task updated successfully.');
+        } else {
+          await taskService.createTask(accessToken, payload);
+          toast.success('Task created successfully.');
+    }
+
+    formikHelpers.resetForm();
+        setEditingTaskId(null);
+        await fetchTasks();
+      } catch (error) {
+        toast.error(getErrorMessage(error, 'Unable to save task.'));
+      } finally {
+        setIsSubmittingTask(false);
+      }
+    },
+  });
+
+  const handleEditTask = (task: Task) => {
+    setEditingTaskId(task.id);
+    formik.setValues({ title: task.title, description: task.description });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingTaskId(null);
+    formik.resetForm();
+  };
+
+  const handleDeleteTask = async (task: Task) => {
+    if (!accessToken) {
+      toast.error('You need to be logged in to manage tasks.');
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Are you sure you want to delete "${task.title}"?`,
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setDeletingTaskId(task.id);
+    try {
+      await taskService.deleteTask(accessToken, task.id);
+      toast.success('Task deleted successfully.');
+      await fetchTasks();
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Unable to delete task.'));
+    } finally {
+      setDeletingTaskId(null);
+    }
+  };
+
+  const getFieldError = (field: keyof TaskFormValues) =>
+    formik.touched[field] ? (formik.errors[field] as string) : '';
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-6 py-10">
+      <div className="mb-8 rounded-2xl border border-stroke bg-white p-6 shadow-sm">
+        <div className="mb-6">
+          <h1 className="text-2xl font-semibold text-slate-900">Task Manager</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            Create tasks, keep them up to date, and clear the ones you no longer
+            need.
+          </p>
+          {editingTaskId && (
+            <p className="mt-2 text-sm font-medium text-primary">
+              Editing existing task. Make your changes and save, or cancel to go
+              back to creating a new one.
+            </p>
+          )}
+        </div>
+        <form onSubmit={formik.handleSubmit}>
+          <VerticalStackLayout gap={5}>
+            <FormControl label="Title" error={getFieldError('title')}>
+              <Input
+                name="title"
+                placeholder="Add a short, descriptive title"
+                value={formik.values.title}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                disabled={isSubmittingTask}
+              />
+            </FormControl>
+            <FormControl
+              label="Description"
+              error={getFieldError('description')}
+            >
+              <textarea
+                name="description"
+                placeholder="Describe the work that needs to be done"
+                value={formik.values.description}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                disabled={isSubmittingTask}
+                className="h-32 w-full rounded-lg border border-stroke bg-white p-4 text-sm outline-none transition focus:border-primary focus-visible:shadow-none"
+              />
+            </FormControl>
+            <Flex alignItems="center" gap={3}>
+              <div className="w-44">
+                <Button
+                  type={ButtonType.SUBMIT}
+                  isLoading={isSubmittingTask}
+                >
+                  {editingTaskId ? 'Update task' : 'Add task'}
+                </Button>
+              </div>
+              {editingTaskId && (
+                <button
+                  type="button"
+                  className="text-sm font-medium text-slate-600 transition hover:text-slate-900"
+                  onClick={handleCancelEdit}
+                  disabled={isSubmittingTask}
+                >
+                  Cancel
+                </button>
+              )}
+            </Flex>
+          </VerticalStackLayout>
+        </form>
+      </div>
+
+      <div className="rounded-2xl border border-stroke bg-white p-6 shadow-sm">
+        <div className="mb-4 flex items-end justify-between">
+          <h2 className="text-xl font-semibold text-slate-900">Your tasks</h2>
+          <span className="text-sm font-medium text-slate-500">
+            Total: {taskCount}
+          </span>
+        </div>
+
+        {isLoadingTasks ? (
+          <ParagraphMedium>Loading tasks…</ParagraphMedium>
+        ) : tasks.length === 0 ? (
+          <ParagraphMedium>
+            You haven’t created any tasks yet. Use the form above to add your
+            first task.
+          </ParagraphMedium>
+        ) : (
+          <ul className="flex flex-col gap-4">
+            {tasks.map((task) => (
+              <li
+                key={task.id}
+                className="rounded-xl border border-slate-200 p-4 transition hover:border-primary/40"
+              >
+                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <h3 className="text-lg font-semibold text-slate-900">
+                      {task.title}
+                    </h3>
+                    <p className="mt-1 text-sm text-slate-600">
+                      {task.description}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-4">
+                    <button
+                      type="button"
+                      className="text-sm font-medium text-primary transition hover:text-primary/80"
+                      onClick={() => handleEditTask(task)}
+                      disabled={deletingTaskId === task.id || isSubmittingTask}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      className="text-sm font-medium text-red-500 transition hover:text-red-400"
+                      onClick={() => handleDeleteTask(task)}
+                      disabled={deletingTaskId === task.id}
+                    >
+                      {deletingTaskId === task.id ? 'Deleting…' : 'Delete'}
+                    </button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Tasks;

--- a/src/apps/frontend/routes/protected.tsx
+++ b/src/apps/frontend/routes/protected.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
 import toast from 'react-hot-toast';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet, useNavigate } from 'react-router-dom';
 
 import routes from 'frontend/constants/routes';
 import { useAccountContext, useAuthContext } from 'frontend/contexts';
-import { Dashboard, NotFound } from 'frontend/pages';
+import { NotFound, Tasks } from 'frontend/pages';
 import AppLayout from 'frontend/pages/app-layout/app-layout';
 import { AsyncError } from 'frontend/types';
 
@@ -28,12 +28,17 @@ const App = () => {
   );
 };
 
+const tasksRoutePath = routes.TASKS.startsWith('/')
+  ? routes.TASKS.slice(1)
+  : routes.TASKS;
+
 export const protectedRoutes = [
   {
     path: '',
     element: <App />,
     children: [
-      { path: '', element: <Dashboard /> },
+      { index: true, element: <Navigate to={routes.TASKS} replace /> },
+      { path: tasksRoutePath, element: <Tasks /> },
       { path: '*', element: <NotFound /> },
     ],
   },

--- a/src/apps/frontend/services/index.ts
+++ b/src/apps/frontend/services/index.ts
@@ -2,5 +2,6 @@ import AccountService from 'frontend/services/account.service';
 import APIService from 'frontend/services/api.service';
 import AuthService from 'frontend/services/auth.service';
 import ResetPasswordService from 'frontend/services/reset-password.service';
+import TaskService from 'frontend/services/task.service';
 
-export { AccountService, APIService, AuthService, ResetPasswordService };
+export { AccountService, APIService, AuthService, ResetPasswordService, TaskService };

--- a/src/apps/frontend/services/task.service.ts
+++ b/src/apps/frontend/services/task.service.ts
@@ -1,0 +1,86 @@
+import APIService from 'frontend/services/api.service';
+import { AccessToken, ApiResponse } from 'frontend/types';
+import { JsonObject } from 'frontend/types/common-types';
+import {
+  PaginatedTasks,
+  Task,
+  TaskPayload,
+} from 'frontend/types/task';
+
+export default class TaskService extends APIService {
+  private getAuthHeaders(accessToken: AccessToken) {
+    return {
+      Authorization: `Bearer ${accessToken.token}`,
+    };
+  }
+
+  private getTasksUrl(accessToken: AccessToken, taskId?: string) {
+    const taskPath = taskId ? `/tasks/${taskId}` : '/tasks';
+    return `/accounts/${accessToken.accountId}${taskPath}`;
+  }
+
+  async listTasks(
+    accessToken: AccessToken,
+    params?: { page?: number; size?: number },
+  ): Promise<ApiResponse<PaginatedTasks>> {
+    const query: Record<string, number> = {};
+    if (params?.page) {
+      query.page = params.page;
+    }
+    if (params?.size) {
+      query.size = params.size;
+    }
+
+    const response = await this.apiClient.get<JsonObject>(
+      this.getTasksUrl(accessToken),
+      {
+        headers: this.getAuthHeaders(accessToken),
+        params: query,
+      },
+    );
+
+    return new ApiResponse(new PaginatedTasks(response.data as JsonObject));
+  }
+
+  async createTask(
+    accessToken: AccessToken,
+    payload: TaskPayload,
+  ): Promise<ApiResponse<Task>> {
+    const response = await this.apiClient.post<JsonObject>(
+      this.getTasksUrl(accessToken),
+      payload,
+      {
+        headers: this.getAuthHeaders(accessToken),
+      },
+    );
+
+    return new ApiResponse(new Task(response.data as JsonObject));
+  }
+
+  async updateTask(
+    accessToken: AccessToken,
+    taskId: string,
+    payload: TaskPayload,
+  ): Promise<ApiResponse<Task>> {
+    const response = await this.apiClient.patch<JsonObject>(
+      this.getTasksUrl(accessToken, taskId),
+      payload,
+      {
+        headers: this.getAuthHeaders(accessToken),
+      },
+    );
+
+    return new ApiResponse(new Task(response.data as JsonObject));
+  }
+
+  async deleteTask(
+    accessToken: AccessToken,
+    taskId: string,
+  ): Promise<ApiResponse<void>> {
+    await this.apiClient.delete(this.getTasksUrl(accessToken, taskId), {
+      headers: this.getAuthHeaders(accessToken),
+    });
+
+    return new ApiResponse();
+  }
+}

--- a/src/apps/frontend/types/index.ts
+++ b/src/apps/frontend/types/index.ts
@@ -8,6 +8,7 @@ import {
 } from 'frontend/types/async-operation';
 import { AccessToken, KeyboardKeys, PhoneNumber } from 'frontend/types/auth';
 import { ApiResponse, ApiError } from 'frontend/types/service-response';
+import { PaginatedTasks, Task, TaskPayload } from 'frontend/types/task';
 import { UserMenuDropdownItem } from 'frontend/types/user-menu-dropdown-item';
 
 export {
@@ -19,6 +20,9 @@ export {
   AsyncResult,
   KeyboardKeys,
   PhoneNumber,
+  PaginatedTasks,
+  Task,
+  TaskPayload,
   UseAsyncResponse,
   DatadogUser,
   UserMenuDropdownItem,

--- a/src/apps/frontend/types/task.ts
+++ b/src/apps/frontend/types/task.ts
@@ -1,0 +1,53 @@
+import { JsonObject } from 'frontend/types/common-types';
+
+export type TaskPayload = {
+  title: string;
+  description: string;
+};
+
+export class Task {
+  id: string;
+  accountId: string;
+  title: string;
+  description: string;
+
+  constructor(json: JsonObject) {
+    this.id = (json.id as string) ?? '';
+    this.accountId = (json.account_id as string) ?? '';
+    this.title = (json.title as string) ?? '';
+    this.description = (json.description as string) ?? '';
+  }
+}
+
+export class PaginationParams {
+  page: number;
+  size: number;
+  offset: number;
+
+  constructor(json: JsonObject) {
+    this.page = (json.page as number) ?? 1;
+    this.size = (json.size as number) ?? 0;
+    this.offset = (json.offset as number) ?? 0;
+  }
+}
+
+export class PaginatedTasks {
+  items: Task[];
+  paginationParams: PaginationParams;
+  totalCount: number;
+  totalPages: number;
+
+  constructor(json: JsonObject) {
+    const items = Array.isArray(json.items)
+      ? (json.items as JsonObject[]).map((item) => new Task(item))
+      : [];
+
+    this.items = items;
+    const paginationParams =
+      (json.pagination_params as JsonObject | undefined) ?? {};
+
+    this.paginationParams = new PaginationParams(paginationParams);
+    this.totalCount = (json.total_count as number) ?? items.length;
+    this.totalPages = (json.total_pages as number) ?? 1;
+  }
+}


### PR DESCRIPTION
## Description
- add a typed `TaskService` plus task domain models to consume the existing task CRUD endpoints
- expose a new `/tasks` page that lets users create, edit, and delete tasks with validation, inline status cues, and toast feedback
- reroute authenticated traffic to the task workspace, wire the sidebar entry, and clean up exports so the feature is reachable from the shell

### Manual test cases run
- Log in, open `/tasks`, create a fresh task ⇒ saw success toast and task listed immediately
- From the list, choose “Edit”, change title/description, submit ⇒ form reset, list refreshed with updated copy
- Click “Delete” for a task, confirm the prompt ⇒ toast confirms removal and entry disappears

### Additional Notes
- Changes mirror the reference PR’s UX but remain narrower in scope (no dashboard rewrite, no provider refactors) to stay aligned with this backend’s contracts.
- `window.confirm` handles deletion confirmation; swap for a modal if a richer experience is desired later.
- Access tokens are still sourced from storage; if token refresh logic appears later we can lift it into a dedicated hook or context.